### PR TITLE
Fix index price klines to use pair query parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Changelog
 
 ## [Unreleased]
+- fix: prevent index price klines from returning HTTP 400 by using the `pair` query key
 - chore: initialize Binance USDS-M data collector workflow and scripts

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ RATIO_PERIOD = "1h"                            # Long/Short, Taker Vol 주기
 - `{symbol}_mark_{INTERVAL}_{DAYS}d.csv`
 - `{symbol}_premium_{INTERVAL}_{DAYS}d.csv`
 
+> 지수 가격(Index Price) 엔드포인트(`/fapi/v1/indexPriceKlines`)는 Binance 사양상 `pair` 파라미터를 요구하므로, 스크립트가 자동으로 해당 키를 사용해 HTTP 400 오류를 방지합니다.
+
 ## 실행 방법
 ### 로컬 실행
 1. Python 3.11 이상과 가상환경을 준비합니다.

--- a/tests/test_collector.py
+++ b/tests/test_collector.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+pd = pytest.importorskip("pandas")
+
+import collector
+
+
+def test_paginate_fetch_uses_custom_symbol_param(monkeypatch):
+    captured: dict[str, Any] = {}
+
+    def fake_get(path: str, params: dict[str, Any]) -> list[list[int]]:
+        captured["path"] = path
+        captured["params"] = params.copy()
+        return [[0]]
+
+    monkeypatch.setattr(collector, "_get", fake_get)
+
+    rows = collector.paginate_fetch(
+        path="/example",
+        symbol="BTCUSDT",
+        limit=1,
+        earliest_ms=0,
+        build_params=lambda params: None,
+        extract_timestamp=lambda row: int(row[0]),
+        symbol_param="pair",
+    )
+
+    assert rows == [[0]]
+    assert captured["path"] == "/example"
+    assert captured["params"]["pair"] == "BTCUSDT"
+    assert "symbol" not in captured["params"]
+
+
+def test_fetch_index_like_forwards_symbol_param(monkeypatch):
+    expected_rows = [[0, 1, 2, 3, 4, 5, 6, 7, 8]]
+
+    def fake_paginate_fetch(**kwargs: Any) -> list[list[int]]:
+        assert kwargs["symbol_param"] == "pair"
+        build_params = kwargs["build_params"]
+        params: dict[str, Any] = {}
+        build_params(params)
+        assert params == {"interval": "1m"}
+        return expected_rows
+
+    monkeypatch.setattr(collector, "paginate_fetch", fake_paginate_fetch)
+
+    frame = collector.fetch_index_like(
+        "BTCUSDT",
+        "/fapi/v1/indexPriceKlines",
+        "1m",
+        1,
+        symbol_param="pair",
+    )
+
+    assert isinstance(frame, pd.DataFrame)
+    assert frame.iloc[0]["open_time"] == 0
+    assert list(frame.columns) == [
+        "open_time",
+        "open",
+        "high",
+        "low",
+        "close",
+        "volume",
+        "close_time",
+        "base_asset_volume",
+        "trades",
+    ]


### PR DESCRIPTION
## 배경/문제
- Binance Index Price Klines 엔드포인트가 `symbol` 대신 `pair` 파라미터를 요구하면서 HTTP 400이 발생했습니다.

## 핵심 변경
- 페이지네이션 유틸리티와 지수/마크/프리미엄 라인 수집 로직이 커스텀 심볼 파라미터 키를 허용하도록 확장했습니다.
- Index Price Klines 호출 시 `pair` 키를 사용하도록 조정하고, 동작을 검증하는 단위 테스트를 추가했습니다.
- README와 CHANGELOG에 변경 사항과 오류 방지 동작을 문서화했습니다.

## 테스트/검증
- `pytest -q` *(pandas 미설치로 테스트 모듈 전체가 건너뜀)*
- `python collector.py` *(pandas 미설치로 스크립트 실행 불가)*

## 호환성/리스크
- 마크/프리미엄 Klines는 기존 `symbol` 키를 계속 사용하므로 호환성 영향은 없습니다. 문제가 있을 경우 커밋을 롤백하면 됩니다.

## 체크리스트
- [ ] 테스트 통과 (pandas 미설치)
- [ ] 린트
- [ ] 타입체크
- [x] 문서 갱신(README/CHANGELOG)


------
https://chatgpt.com/codex/tasks/task_e_68e36d411c34833186fe5689e1f206fb